### PR TITLE
Adapted to the new DB structure

### DIFF
--- a/CodenameIndigo/Modules/Commands/MaintenancePanelCommand.cs
+++ b/CodenameIndigo/Modules/Commands/MaintenancePanelCommand.cs
@@ -67,7 +67,7 @@ namespace CodenameIndigo.Modules.Commands
             {
                 await conn.OpenAsync();
 
-                MySqlCommand cmd = new MySqlCommand("SELECT `end_date` FROM `setup` WHERE `tourney_id` = 1", conn);
+                MySqlCommand cmd = new MySqlCommand("SELECT `regend` FROM `tournaments` WHERE `tid` = 1", conn);
 
                 long UNIXTime = 0;
 
@@ -110,7 +110,7 @@ namespace CodenameIndigo.Modules.Commands
                         {
                             await conn.OpenAsync();
 
-                            cmd = new MySqlCommand($"UPDATE `setup` SET `end_date` = {date.ToUnixTimeSeconds()}  WHERE `tourney_id` = 1", conn);
+                            cmd = new MySqlCommand($"UPDATE `tournaments` SET `regend` = {date.ToUnixTimeSeconds()}  WHERE `tid` = 1", conn);
                             await cmd.ExecuteNonQueryAsync();
                             await channel.SendMessageAsync("", false, new EmbedBuilder() { Title = "Edit Succesfull!", Color = Color.Green, Description = "Successfully changed the date. Returning to menu." });
                             await Task.Delay(1000);
@@ -145,7 +145,7 @@ namespace CodenameIndigo.Modules.Commands
             {
                 await conn.OpenAsync();
 
-                MySqlCommand cmd = new MySqlCommand("SELECT `min_players` FROM `setup` WHERE `tourney_id` = 1", conn);
+                MySqlCommand cmd = new MySqlCommand("SELECT `minplayers` FROM `tournaments` WHERE `tid` = 1", conn);
 
                 int min_players = 0;
 
@@ -182,7 +182,7 @@ namespace CodenameIndigo.Modules.Commands
                                 try
                                 {
                                     await conn.OpenAsync();
-                                    cmd = new MySqlCommand($"UPDATE `setup` SET `min_players` = {input}  WHERE `tourney_id` = 1", conn);
+                                    cmd = new MySqlCommand($"UPDATE `tournaments` SET `minplayers` = {input}  WHERE `tid` = 1", conn);
                                     await cmd.ExecuteNonQueryAsync();
                                     await channel.SendMessageAsync("", false, new EmbedBuilder() { Title = "Edit Succesfull!", Color = Color.Green, Description = "Successfully changed the min player amount. Returning to menu." });
                                     await Task.Delay(1000);
@@ -228,7 +228,7 @@ namespace CodenameIndigo.Modules.Commands
             {
                 await conn.OpenAsync();
 
-                MySqlCommand cmd = new MySqlCommand("SELECT `max_players` FROM `setup` WHERE `tourney_id` = 1", conn);
+                MySqlCommand cmd = new MySqlCommand("SELECT `maxplayers` FROM `tournaments` WHERE `tid` = 1", conn);
 
                 int max_players = 0;
 
@@ -244,7 +244,6 @@ namespace CodenameIndigo.Modules.Commands
                 {
                     Title = "Registration Max Players",
                     Description = $"The current maximum amount of players is {max_players} (minimum maximum is 2)\n" +
-                    $"If the maximum is `-1` there is no maximum." +
                     $"If you would like to alter it, please send `edit`. Send anything else to return to the main menu."
                 });
                 await Task.Delay(500);
@@ -253,7 +252,7 @@ namespace CodenameIndigo.Modules.Commands
                 if (response.Content.ToLower().StartsWith("edit"))
                 {
                     Min_Players:
-                    await channel.SendMessageAsync("", false, new EmbedBuilder() { Title = "Registration Max Players", Description = "What will be the maximum amount of players? (min 2, -1 for unlimited)" });
+                    await channel.SendMessageAsync("", false, new EmbedBuilder() { Title = "Registration Max Players", Description = "What will be the maximum amount of players? (min 2)" });
                     await Task.Delay(500);
 
                     response = await NextMessageAsync(new EnsureChannelCriterion(channel.Id), TimeSpan.FromMinutes(2));
@@ -261,12 +260,12 @@ namespace CodenameIndigo.Modules.Commands
                     {
                         if (Int32.TryParse(response.Content, out int input))
                         {
-                            if (input >= 2 || input == -1)
+                            if (input >= 2)
                             {
                                 try
                                 {
                                     await conn.OpenAsync();
-                                    cmd = new MySqlCommand($"UPDATE `setup` SET `min_players` = {input}  WHERE `tourney_id` = 1", conn);
+                                    cmd = new MySqlCommand($"UPDATE `tournaments` SET `maxplayers` = {input}  WHERE `tid` = 1", conn);
                                     await cmd.ExecuteNonQueryAsync();
                                     await channel.SendMessageAsync("", false, new EmbedBuilder() { Title = "Edit Succesfull!", Color = Color.Green, Description = "Successfully changed the max player amount. Returning to menu." });
                                     await Task.Delay(1000);
@@ -279,7 +278,7 @@ namespace CodenameIndigo.Modules.Commands
                             }
                             else
                             {
-                                await channel.SendMessageAsync("", false, new EmbedBuilder() { Title = "Wrong Input!", Color = Color.Red, Description = "Please input a number higher than 1 or -1." });
+                                await channel.SendMessageAsync("", false, new EmbedBuilder() { Title = "Wrong Input!", Color = Color.Red, Description = "Please input a number higher than 1." });
                                 goto Min_Players;
                             }
                         }

--- a/CodenameIndigo/Modules/Commands/RegistrationCommands.cs
+++ b/CodenameIndigo/Modules/Commands/RegistrationCommands.cs
@@ -104,7 +104,7 @@ namespace CodenameIndigo.Modules
             {
                 await conn.OpenAsync();
 
-                string cmdString = $"INSERT INTO users (UUID, DiscordUsername, ShowdownUsername, Team) VALUES ('{player.Id}', '{player.DiscordName}', @ShowdownUsername, @Team)";
+                string cmdString = $"INSERT INTO participants (tid, uid, discordusername, showdownusername, team) VALUES (1, '{player.Id}', '{player.DiscordName}', @ShowdownUsername, @Team)";
                 MySqlCommand cmd = new MySqlCommand(cmdString, conn);
                 cmd.Parameters.Add("@ShowdownUsername", MySqlDbType.VarChar).Value = player.ShowdownName;
                 cmd.Parameters.Add("@Team", MySqlDbType.VarChar).Value = player.Team;

--- a/CodenameIndigo/Modules/Commands/TeamLookupCommand.cs
+++ b/CodenameIndigo/Modules/Commands/TeamLookupCommand.cs
@@ -20,7 +20,7 @@ namespace CodenameIndigo.Modules.Commands
             {
                 await conn.OpenAsync();
 
-                string cmdString = $"SELECT Team FROM users WHERE UUID = {mention.Id}";
+                string cmdString = $"SELECT team FROM participants WHERE tid = 1 AND uid = {mention.Id}";
                 MySqlCommand cmd = new MySqlCommand(cmdString, conn);
 
                 string team = "";
@@ -28,7 +28,7 @@ namespace CodenameIndigo.Modules.Commands
                 {
                     while (await reader.ReadAsync())
                     {
-                        team = reader.GetString(reader.GetOrdinal("Team"));
+                        team = reader.GetString(reader.GetOrdinal("team"));
                     }
                 }
                 if (string.IsNullOrEmpty(team))

--- a/CodenameIndigo/Modules/Preconditions/InSignupPrecon.cs
+++ b/CodenameIndigo/Modules/Preconditions/InSignupPrecon.cs
@@ -18,7 +18,7 @@ namespace CodenameIndigo.Modules.Preconditions
             {
                 await conn.OpenAsync();
 
-                MySqlCommand cmd = new MySqlCommand("SELECT `end_date` FROM `setup` WHERE `tourney_id` = 1", conn);
+                MySqlCommand cmd = new MySqlCommand("SELECT `regend` FROM `tournaments` WHERE `tid` = 1", conn);
 
 
 

--- a/CodenameIndigo/Modules/Preconditions/UserNotRegisteredPrecon.cs
+++ b/CodenameIndigo/Modules/Preconditions/UserNotRegisteredPrecon.cs
@@ -18,7 +18,7 @@ namespace CodenameIndigo.Modules.Preconditions
             {
                 await conn.OpenAsync();
 
-                string cmdString = $"SELECT COUNT(UUID) FROM users WHERE UUID = {context.User.Id}";
+                string cmdString = $"SELECT COUNT(uid) FROM participants WHERE uid = {context.User.Id}";
                 MySqlCommand cmd = new MySqlCommand(cmdString, conn);
 
                 using (MySqlDataReader reader = (MySqlDataReader)await cmd.ExecuteReaderAsync())


### PR DESCRIPTION
**For application of #18**

Multiple things would still need adapting:
- first and biggest change: the resettourney command shouldn't just destroy the tournament, but instead create a new one
- each time information about the tournament is requested, it is with tournament ID tid=1, it should use the tourney for which the date is compatible [for example : if registrations are currently open for the fourth tourney we organize, it should use tid=4 based on the dates]

Staff should be made able to create a tourney: that would just add a line in the tournaments table.

When a user registers for a tournament, they should be added to the participants database along with the tid of the tournament they registered for.

Ask me if you need more info 👀 

The database specs:
![image](https://user-images.githubusercontent.com/31666847/36067892-6f1f50b0-0ec8-11e8-9a69-88a0d9bceb90.png)

Tables users and setup to be removed once everything has been tested and everything. (I leave them for the moment just in case.) 'night!